### PR TITLE
Zero out lfs_config at start

### DIFF
--- a/src/107-Arduino-littlefs.h
+++ b/src/107-Arduino-littlefs.h
@@ -99,6 +99,8 @@ public:
                    lfs_size_t const cache_size,
                    lfs_size_t const lookahead_size)
   {
+    memset(&_cfg, 0, sizeof(_cfg));
+
     _cfg.read  = read_func;
     _cfg.prog  = prog_func;
     _cfg.erase = erase_func;


### PR DESCRIPTION
Set all fields not explicitly address in c'tor to a default value